### PR TITLE
Fix version conflicts caused by PR#100

### DIFF
--- a/samples/Common.Razor.Demo/Common.Razor.Demo.csproj
+++ b/samples/Common.Razor.Demo/Common.Razor.Demo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/src/Common.Razor/Common.Razor.csproj
+++ b/src/Common.Razor/Common.Razor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
     <RootNamespace>Jpp.Common.Razor</RootNamespace>
     <PackageId>Jpp.Common.Razor</PackageId>
@@ -17,9 +17,9 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.8" />
   </ItemGroup>
 
 

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <RootNamespace>Jpp.Common</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Jpp.Common</PackageId>

--- a/tests/Common.Razor.Tests/Common.Razor.Tests.csproj
+++ b/tests/Common.Razor.Tests/Common.Razor.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Common.Tests/Common.Tests.csproj
+++ b/tests/Common.Tests/Common.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.AspNetCore.Components from 3.1.9 to 5.0.8. [(PR#100)](https://github.com/JPPGroup/Common/pull/100).
Hope this fix can help you.

Best regards,
sucrose